### PR TITLE
Adding the AWS domain name to the django setting file for allowed hosts

### DIFF
--- a/src/profiles_project/profiles_project/settings.py
+++ b/src/profiles_project/profiles_project/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = '&rq6bylv^l%5kemm6bhike)!a)txcoomng8p*q^7^0rxe0ta)i'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['ec2-13-59-85-157.us-east-2.compute.amazonaws.com']
 
 
 # Application definition


### PR DESCRIPTION
Adding the AWS ec2 instance domain name to the framework setting allowed hosts